### PR TITLE
bump-to-version-0.1.2b1

### DIFF
--- a/examples/readme.md
+++ b/examples/readme.md
@@ -3,13 +3,12 @@
 1. Place your dbt `manifest.json` and `catalog.json` files in the `inputs` directory.
 2. **Customization**:
    - Set your dialect (only tested with `snowflake` so far) in the `main_step_1_direct.py` script.
-   - Modify the `li_selected_model` list in `main_step_1_direct.py` to specify the scan scope, or leave it empty to process all models.
+   - You can specify the scope of the models you want to extract column lineage for by adding them to the `li_selected_model` list, or leave it empty to process all models (recommended).
 
 3. Run the `main_step_1_direct.py` script to extract direct column lineage:
    ```bash
    python main_step_1_direct.py
    ```
-   - You can specify the models you want to extract column lineage for by adding them to the `li_selected_model` list or leave it empty to process all models (recommended).
 
 4. This will generate **direct** column lineage relationships for all models in the `outputs` directory.
    - `lineage_to_direct_parents.json`

--- a/py_package/dbt_column_lineage_extractor/cli_direct.py
+++ b/py_package/dbt_column_lineage_extractor/cli_direct.py
@@ -6,7 +6,7 @@ def main():
     parser = argparse.ArgumentParser(description="DBT Column Lineage Extractor CLI")
     parser.add_argument('--manifest', default='./inputs/manifest.json', help='Path to the manifest.json file, default to ./inputs/manifest.json')
     parser.add_argument('--catalog', default='./inputs/catalog.json', help='Path to the catalog.json file, default to ./inputs/catalog.json')
-    parser.add_argument('--dialect', default='snowflake', help='SQL dialect to use, default is snowflake')
+    parser.add_argument('--dialect', default='snowflake', help='SQL dialect to use, default is snowflake, more dialects at https://github.com/tobymao/sqlglot/tree/v25.24.5/sqlglot/dialects')
     parser.add_argument('--model', nargs='*', default=[], help='List of models to extract lineage for, default to all models')
     parser.add_argument('--output-dir', default='./outputs', help='Directory to write output json files, default to ./outputs')
     parser.add_argument('--show-ui', action='store_true', help='Flag to show lineage outputs in the console')

--- a/py_package/setup.py
+++ b/py_package/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='dbt_column_lineage_extractor',
-    version='0.1.1',
+    version='0.1.2b1',
     description='A package for extracting dbt column lineage',
     long_description=open('../README.md').read(),
     long_description_content_type='text/markdown',

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,10 @@
 # DBT Column Lineage Extractor
 
+# DISCLAIMER
+
+**WARNING:** This tool is currently in beta and has only been tested on a limited number of dbt projects using the `snowflake` dialect. It might not perform as expected in every situation. Please report any issues or suggestions in the [Repository](https://github.com/canva-public/dbt-column-lineage-extractor)
+
+
 ## Overview
 
 The DBT Column Lineage Extractor is a lightweight Python-based tool for extracting and analyzing data column lineage for dbt projects. This tool utilizes the [sqlglot](https://github.com/tobymao/sqlglot) library to parse and analyze SQL queries defined in your dbt models and maps their column lineage relationships.
@@ -127,4 +132,5 @@ The structured JSON outputs can be used programmatically, or loaded into visuali
 ## Limitations
 - Doesn’t support parse certain syntax, e.g. lateral flatten
 - Doesn’t support dbt python models
+- Only tested with `snowflake` dialect so far
 


### PR DESCRIPTION
This pull request includes updates to the documentation, enhancements to the command-line interface, and a version bump for the `dbt_column_lineage_extractor` package.

Documentation updates:

* [`readme.md`](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R3-R7): Added a disclaimer about the beta status of the tool and its limited testing with the `snowflake` dialect.
* [`examples/readme.md`](diffhunk://#diff-3c899d1a528e52a3e4a53324554ae61d1410275a863a1040970213da72952bebL6-L12): Updated the instructions to clarify how to specify the scope of models for column lineage extraction.
* [`readme.md`](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R135): Noted that the tool has only been tested with the `snowflake` dialect.

CLI enhancements:

* [`py_package/dbt_column_lineage_extractor/cli_direct.py`](diffhunk://#diff-21d5b912edb34cbd2f72dadc02db37d3321c72ef9d05d154bd1def4aad445cdeL9-R9): Enhanced the `--dialect` argument description to include a link to more supported dialects.

Version bump:

* [`py_package/setup.py`](diffhunk://#diff-dda2a8713d2303875b0444a2f6de6c8343418666d27eb5d79931f9bb80ec5cc1L5-R5): Updated the package version from `0.1.1` to `0.1.2b1`.…ns; enhance CLI help descriptions; bump to version 0.1.2b1