### PR TITLE
3 keyerror when using examplesmain step 1 directpy

### DIFF
--- a/py_package/dbt_column_lineage_extractor/.gitignore
+++ b/py_package/dbt_column_lineage_extractor/.gitignore
@@ -1,0 +1,4 @@
+main_step_1_direct.py
+main_step_2_recursive.py
+inputs/*
+outputs/*

--- a/py_package/setup.py
+++ b/py_package/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='dbt_column_lineage_extractor',
-    version='0.1.2b2',
+    version='0.1.3b1',
     description='A package for extracting dbt column lineage',
     long_description=open('../README.md').read(),
     long_description_content_type='text/markdown',

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ The DBT Column Lineage Extractor is a lightweight Python-based tool for extracti
 ## Installation
 ### pip installation
 ```
-pip install dbt-column-lineage-extractor==0.1.2b2
+pip install dbt-column-lineage-extractor==0.1.3b1
 ```
 
 ## Required Input Files


### PR DESCRIPTION
### PR Summery

This pull request includes several changes to the `dbt_column_lineage_extractor` package, focusing on standardizing table and column names to lowercase, updating the version

### Standardization of table and column names to lowercase:
* [`py_package/dbt_column_lineage_extractor/extractor.py`](diffhunk://#diff-01af497d4b1aaf7f1d2e11d5fd7244790ddee8d35d43b9661d5b5b603ce26a79L147-R150): Modified functions to convert table and column names to lowercase to ensure consistency. [[1]](diffhunk://#diff-01af497d4b1aaf7f1d2e11d5fd7244790ddee8d35d43b9661d5b5b603ce26a79L147-R150) [[2]](diffhunk://#diff-01af497d4b1aaf7f1d2e11d5fd7244790ddee8d35d43b9661d5b5b603ce26a79R159) [[3]](diffhunk://#diff-01af497d4b1aaf7f1d2e11d5fd7244790ddee8d35d43b9661d5b5b603ce26a79R184-R189) [[4]](diffhunk://#diff-01af497d4b1aaf7f1d2e11d5fd7244790ddee8d35d43b9661d5b5b603ce26a79L195-R205) [[5]](diffhunk://#diff-01af497d4b1aaf7f1d2e11d5fd7244790ddee8d35d43b9661d5b5b603ce26a79R229) [[6]](diffhunk://#diff-01af497d4b1aaf7f1d2e11d5fd7244790ddee8d35d43b9661d5b5b603ce26a79L243-R263)

### Version update:
* [`py_package/setup.py`](diffhunk://#diff-dda2a8713d2303875b0444a2f6de6c8343418666d27eb5d79931f9bb80ec5cc1L5-R5): Updated the package version from `0.1.2b2` to `0.1.3b1`.

### Linked Issue
https://github.com/canva-public/dbt-column-lineage-extractor/issues/3
