### PR TITLE
full table names for manifest and catalog should be lowercase

### DIFF
--- a/py_package/dbt_column_lineage_extractor/extractor.py
+++ b/py_package/dbt_column_lineage_extractor/extractor.py
@@ -270,7 +270,7 @@ class DBTNodeCatalog:
 
     @property
     def full_table_name(self):
-        return f"{self.database}.{self.schema}.{self.name}"
+        return f"{self.database}.{self.schema}.{self.name}".lower()
 
     def get_column_types(self):
         return {col_name: col_info["type"] for col_name, col_info in self.columns.items()}
@@ -285,7 +285,7 @@ class DBTNodeManifest:
 
     @property
     def full_table_name(self):
-        return f"{self.database}.{self.schema}.{self.name}"
+        return f"{self.database}.{self.schema}.{self.name}".lower()
 
 
 # TODO: add metadata columns to external tables


### PR DESCRIPTION
Hey there! 

I hope it is fine if I open this PR, please feel free to close if you feel like it breaks other functionalities.

While checking out this package, I stumbled on the following error:
```
Processing model model.dbt_project.model_name
/usr/local/lib/python3.9/site-packages/dbt_column_lineage_extractor/extractor.py:149: UserWarning: Table database.schema.model_name not found in node mapping
  warnings.warn(f"Table {table_name} not found in node mapping")
```

After some debugging, I realized the issue was in the [following function](https://github.com/canva-public/dbt-column-lineage-extractor/blob/193529e2dd812e3e0dbdbc5a553c4c9ce8fff213/py_package/dbt_column_lineage_extractor/extractor.py#L146), when trying to match the dict key with the selected model full name.

This happens because the `manifest.json`, for example, has the database and schema fields in uppercase
```
"database": "DB_NAME",
"schema": "SCHEMA_NAME"
```